### PR TITLE
chore: codeowners -> comet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/comet


### PR DESCRIPTION
We think this is used in Registry for webhooks, and verifying the signatures thereof; maybe related to Heroku?

Can someone from Comet please take ownership of this, and work out what's going on, and whether we can .. not have this, please?